### PR TITLE
Slight changes to Makefile.xenon

### DIFF
--- a/Makefile.xenon
+++ b/Makefile.xenon
@@ -61,5 +61,5 @@ clean:
 
 install: all
 	test -d $(DESTDIR)/$(PREFIX)/include/SDL/ || mkdir -p $(DESTDIR)/$(PREFIX)/include/SDL/
-	cp -r include/* $(DESTDIR)/$(PREFIX/include/SDL/
+	cp -r include/* $(DESTDIR)/$(PREFIX)/include/SDL/
 	install -m 664 $(TARGET) $(DESTDIR)/$(PREFIX)/lib/$(TARGET)

--- a/Makefile.xenon
+++ b/Makefile.xenon
@@ -53,8 +53,13 @@ $(CONFIG_H):
 clean:
 	rm -f $(TARGET) $(OBJECTS)
 
+#install: all
+#	rm -f /usr/xenon/include/SDL/ -R
+#	mkdir /usr/xenon/include/SDL/
+#	cp -r include/* /usr/xenon/include/SDL/ 
+#	cp $(TARGET) /usr/xenon/lib/$(TARGET)
+
 install: all
-	rm -f /usr/xenon/include/SDL/ -R
-	mkdir /usr/xenon/include/SDL/
-	cp -r include/* /usr/xenon/include/SDL/ 
-	cp $(TARGET) /usr/xenon/lib/$(TARGET)
+	test -d $(DESTDIR)/$(PREFIX)/include/SDL/ || mkdir -p $(DESTDIR)/$(PREFIX)/include/SDL/
+	cp -r include/* $(DESTDIR)/$(PREFIX/include/SDL/
+	install -m 664 $(TARGET) $(DESTDIR)/$(PREFIX)/lib/$(TARGET)

--- a/Makefile.xenon
+++ b/Makefile.xenon
@@ -61,5 +61,6 @@ clean:
 
 install: all
 	test -d $(DESTDIR)/$(PREFIX)/include/SDL/ || mkdir -p $(DESTDIR)/$(PREFIX)/include/SDL/
+	test -d $(DESTDIR)/$(PREFIX)/lib/ || mkdir -p $(DESTDIR)/$(PREFIX)/lib/
 	cp -r include/* $(DESTDIR)/$(PREFIX)/include/SDL/
 	install -m 664 $(TARGET) $(DESTDIR)/$(PREFIX)/lib/$(TARGET)

--- a/Makefile.xenon
+++ b/Makefile.xenon
@@ -7,7 +7,7 @@ AR	= xenon-ar
 AS	= xenon-as
 RANLIB	= xenon-ranlib
 
-CFLAGS=$(INCLUDE) -ffunction-sections -fdata-sections  -mno-altivec -mhard-float -mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 -I$(DEVKITXENON)/usr/include/
+CFLAGS=$(INCLUDE) -ffunction-sections -fdata-sections  -mno-altivec -mhard-float -mcpu=cell -mtune=cell -m32 -fno-pic -mpowerpc64 -I/usr/xenon/include/
 
 CONFIG_H = include/SDL_config.h
 TARGET  = libSDL.a
@@ -54,7 +54,7 @@ clean:
 	rm -f $(TARGET) $(OBJECTS)
 
 install: all
-	rm -f $(DEVKITXENON)/usr/include/SDL/ -R
-	mkdir $(DEVKITXENON)/usr/include/SDL/
-	cp -r include/* $(DEVKITXENON)/usr/include/SDL/ 
-	cp $(TARGET) $(DEVKITXENON)/usr/lib/$(TARGET)
+	rm -f /usr/xenon/include/SDL/ -R
+	mkdir /usr/xenon/include/SDL/
+	cp -r include/* /usr/xenon/include/SDL/ 
+	cp $(TARGET) /usr/xenon/lib/$(TARGET)


### PR DESCRIPTION
The changes I made were required to make these repo's work correctly with the debian packaging process, which uses DESTDIR and PREFIX environment variables to install to temp dirs in order to create a finished tree to package.

In order to install to /usr/local/xenon now you would have to do

```
make -f Makefile.xenon PREFIX=/usr/local/xenon install
```

or similar, but perhaps adding another install rule that uses DEVKITXENON instead would be preferable.

Also, i have not tested it, but i think simply defining PREFIX:=$(DEVKITXENON)/usr/ at the top of the makefile would work also.

IIRC, environment variables will override that by default, so if specified the environment variable would take precedent.

Anyway, Im going to be submitting these pull requests for all 3 SDL repo's you have here as I made the changes to them all anyway.
